### PR TITLE
config: flyway dependency 추가

### DIFF
--- a/membership-service/build.gradle.kts
+++ b/membership-service/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
 }
 
 dependencies {
+    implementation("org.flywaydb:flyway-mysql:10.21.0")
+    implementation("org.flywaydb:flyway-core:10.21.0")
+
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 }
 
 tasks.register("prepareKotlinBuildScriptModel"){}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/in/web/controller/FindMembershipController.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/in/web/controller/FindMembershipController.kt
@@ -1,0 +1,50 @@
+package org.rookedsysc.membershipservice.adapter.`in`.web.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.rookedsysc.membershipservice.aop.MembershipTag
+import org.rookedsysc.membershipservice.application.port.`in`.usecase.FindMembershipUsecase
+import org.rookedsysc.membershipservice.domain.MemberShip
+import org.springframework.http.ResponseEntity
+import org.springframework.web.ErrorResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@MembershipTag
+@RequestMapping
+class FindMembershipController(
+    private val findMembershipUsecase: FindMembershipUsecase
+) {
+
+    @Operation(summary = "멤버쉽 조회", description = "멤버쉽 ID로 멤버쉽 정보를 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "성공적으로 조회됨",
+                content = [Content(schema = Schema(implementation = MemberShip::class))]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "멤버쉽을 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    @GetMapping("/membership/{membershipId}")
+    fun getMembership(@PathVariable membershipId: Long): ResponseEntity<MemberShip> {
+        val response: MemberShip = findMembershipUsecase.getMembership(membershipId)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/in/web/controller/RegisterMembershipController.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/in/web/controller/RegisterMembershipController.kt
@@ -1,0 +1,63 @@
+package org.rookedsysc.membershipservice.adapter.`in`.web.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.rookedsysc.membershipservice.adapter.`in`.web.dto.RegisterMembershipRequest
+import org.rookedsysc.membershipservice.aop.MembershipTag
+import org.rookedsysc.membershipservice.application.port.`in`.dto.RegisterMembershipCommand
+import org.rookedsysc.membershipservice.application.port.`in`.usecase.RegisterMembershipUsecase
+import org.rookedsysc.membershipservice.common.constant.MembershipConstatns
+import org.rookedsysc.membershipservice.domain.MemberShip
+import org.springframework.web.ErrorResponse
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@MembershipTag
+@RequestMapping(MembershipConstatns.MEMBERSHIP_REGISTER)
+class RegisterMembershipController(
+    val registerMembershipUsecase: RegisterMembershipUsecase
+) {
+
+    @Operation(summary = "새로운 멤버쉽 등록")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "성공적으로 등록됨",
+                content = [Content(schema = Schema(implementation = MemberShip::class))]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    @PostMapping("/register")
+    fun registerMembership(
+        @Valid @RequestBody registerMembershipRequest: RegisterMembershipRequest
+    ): MemberShip {
+        val command = RegisterMembershipCommand(
+            name = registerMembershipRequest.name,
+            email = registerMembershipRequest.email,
+            address = registerMembershipRequest.address,
+            isValid = registerMembershipRequest.isValid,
+            isCorp = registerMembershipRequest.isCorp
+        )
+
+        return registerMembershipUsecase.registerMembership(command)
+    }
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/in/web/dto/RegisterMembershipRequest.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/in/web/dto/RegisterMembershipRequest.kt
@@ -1,0 +1,31 @@
+package org.rookedsysc.membershipservice.adapter.`in`.web.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.AssertTrue
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+@Schema(description = "회원 등록 요청")
+data class RegisterMembershipRequest(
+    @field:NotBlank
+    @field:Schema(description = "회원 이름", example = "John Doe")
+    val name: String,
+
+    @field:NotBlank
+    @field:Schema(description = "회원 주소", example = "123 Main St")
+    val address: String,
+
+    @field:NotBlank
+    @field:Email
+    @field:Schema(description = "회원 이메일", example = "john.doe@example.com")
+    val email: String,
+
+    @field:AssertTrue
+    @field:Schema(description = "유효성 여부", example = "true")
+    val isValid: Boolean,
+
+    @field:NotNull
+    @field:Schema(description = "법인 여부", example = "false")
+    val isCorp: Boolean
+)

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/out/persistence/MembershipJpaEntity.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/out/persistence/MembershipJpaEntity.kt
@@ -1,0 +1,23 @@
+package org.rookedsysc.membershipservice.adapter.out.persistence
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "membership")
+class MembershipJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    var name: String,
+
+    var email: String,
+
+    var address: String,
+
+    @Column(name = "is_valid")
+    var isValid: Boolean,
+
+    @Column(name = "is_corp")
+    var isCorp: Boolean
+) {}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/out/persistence/MembershipJpaRepository.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/out/persistence/MembershipJpaRepository.kt
@@ -1,0 +1,6 @@
+package org.rookedsysc.membershipservice.adapter.out.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MembershipJpaRepository : JpaRepository<MembershipJpaEntity, Long> {
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/out/persistence/MembershipMapper.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/out/persistence/MembershipMapper.kt
@@ -1,0 +1,29 @@
+package org.rookedsysc.membershipservice.adapter.out.persistence
+
+import org.rookedsysc.membershipservice.application.port.`in`.dto.RegisterMembershipCommand
+import org.rookedsysc.membershipservice.domain.MemberShip
+import org.springframework.stereotype.Component
+
+@Component
+class MembershipMapper {
+    fun toJpaEntity(membershipCommand: RegisterMembershipCommand): MembershipJpaEntity {
+        return MembershipJpaEntity(
+            name = membershipCommand.name,
+            email = membershipCommand.email,
+            address = membershipCommand.address,
+            isValid = membershipCommand.isValid,
+            isCorp = membershipCommand.isCorp
+        )
+    }
+
+    fun toDomainEntity(membershipJpaEntity: MembershipJpaEntity): MemberShip {
+        return MemberShip(
+            id = membershipJpaEntity.id.toString(),
+            name = membershipJpaEntity.name,
+            email = membershipJpaEntity.email,
+            address = membershipJpaEntity.address,
+            isValid = membershipJpaEntity.isValid,
+            isCorp = membershipJpaEntity.isCorp
+        )
+    }
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/out/persistence/MembershipPersistenceAdapter.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/adapter/out/persistence/MembershipPersistenceAdapter.kt
@@ -1,0 +1,19 @@
+package org.rookedsysc.membershipservice.adapter.out.persistence
+
+import org.rookedsysc.membershipservice.application.port.out.FindMembershipPort
+import org.rookedsysc.membershipservice.application.port.out.RegisterMembershipPort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class MembershipPersistenceAdapter(
+    private val membershipJpaRepository: MembershipJpaRepository,
+) : RegisterMembershipPort, FindMembershipPort {
+    override fun createMembership(membershipJpaEntity: MembershipJpaEntity): MembershipJpaEntity {
+        return membershipJpaRepository.save(membershipJpaEntity)
+    }
+
+    override fun getMembership(id: Long): MembershipJpaEntity {
+        return membershipJpaRepository.findByIdOrNull(id) ?: throw IllegalArgumentException("Membership not found")
+    }
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/aop/MembershipTag.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/aop/MembershipTag.kt
@@ -1,0 +1,8 @@
+package org.rookedsysc.membershipservice.aop
+
+import io.swagger.v3.oas.annotations.tags.Tag
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Tag(name = "Membership", description = "멤버쉽 관리 API")
+annotation class MembershipTag

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/port/in/dto/RegisterMembershipCommand.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/port/in/dto/RegisterMembershipCommand.kt
@@ -1,0 +1,40 @@
+package org.rookedsysc.membershipservice.application.port.`in`.dto
+
+import jakarta.validation.ConstraintViolationException
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+import jakarta.validation.ValidatorFactory
+import jakarta.validation.constraints.AssertTrue
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import org.rookedsysc.membershipservice.common.LogConfig
+
+data class RegisterMembershipCommand(
+    @field:NotBlank
+    val name: String,
+
+    @field:NotBlank
+    @field:Email
+    val email: String,
+
+    @field:NotBlank
+    val address: String,
+
+    @field:AssertTrue
+    val isValid: Boolean,
+
+    @field:NotNull
+    val isCorp: Boolean
+) {
+    companion object : LogConfig
+    init {
+        val factory: ValidatorFactory = Validation.buildDefaultValidatorFactory()
+        val validator: Validator = factory.validator
+        val violations = validator.validate(this)
+        if (violations.isNotEmpty()) {
+            log.error("RegisterMembershipCommand validation failed: ${violations.joinToString("\n")}")
+            throw ConstraintViolationException(violations)
+        }
+    }
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/port/in/usecase/FindMembershipUsecase.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/port/in/usecase/FindMembershipUsecase.kt
@@ -1,0 +1,7 @@
+package org.rookedsysc.membershipservice.application.port.`in`.usecase
+
+import org.rookedsysc.membershipservice.domain.MemberShip
+
+interface FindMembershipUsecase {
+    fun getMembership(id: Long): MemberShip
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/port/in/usecase/RegisterMembershipUsecase.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/port/in/usecase/RegisterMembershipUsecase.kt
@@ -1,0 +1,8 @@
+package org.rookedsysc.membershipservice.application.port.`in`.usecase
+
+import org.rookedsysc.membershipservice.application.port.`in`.dto.RegisterMembershipCommand
+import org.rookedsysc.membershipservice.domain.MemberShip
+
+interface RegisterMembershipUsecase {
+    fun registerMembership(command: RegisterMembershipCommand): MemberShip
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/port/out/FindMembershipPort.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/port/out/FindMembershipPort.kt
@@ -1,0 +1,8 @@
+package org.rookedsysc.membershipservice.application.port.out
+
+import org.rookedsysc.membershipservice.adapter.out.persistence.MembershipJpaEntity
+import org.rookedsysc.membershipservice.domain.MemberShip
+
+interface FindMembershipPort {
+    fun getMembership(id: Long): MembershipJpaEntity
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/port/out/RegisterMembershipPort.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/port/out/RegisterMembershipPort.kt
@@ -1,0 +1,8 @@
+package org.rookedsysc.membershipservice.application.port.out
+
+import org.rookedsysc.membershipservice.adapter.out.persistence.MembershipJpaEntity
+import org.rookedsysc.membershipservice.adapter.out.persistence.MembershipJpaRepository
+
+interface RegisterMembershipPort {
+    fun createMembership(membershipJpaEntity: MembershipJpaEntity): MembershipJpaEntity
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/service/FindMembershipService.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/service/FindMembershipService.kt
@@ -1,0 +1,20 @@
+package org.rookedsysc.membershipservice.application.service
+
+import org.rookedsysc.membershipservice.adapter.out.persistence.MembershipJpaEntity
+import org.rookedsysc.membershipservice.adapter.out.persistence.MembershipMapper
+import org.rookedsysc.membershipservice.application.port.`in`.usecase.FindMembershipUsecase
+import org.rookedsysc.membershipservice.application.port.out.FindMembershipPort
+import org.rookedsysc.membershipservice.domain.MemberShip
+import org.springframework.stereotype.Service
+
+@Service
+class FindMembershipService(
+    private val findMembershipPort: FindMembershipPort,
+    private val membershipMapper: MembershipMapper
+) : FindMembershipUsecase{
+    override fun getMembership(id: Long): MemberShip{
+        val membershipJpaRepository: MembershipJpaEntity = findMembershipPort.getMembership(id)
+        val membership: MemberShip = membershipMapper.toDomainEntity(membershipJpaRepository)
+         return membership
+    }
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/service/RegisterMembershipService.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/application/service/RegisterMembershipService.kt
@@ -1,0 +1,23 @@
+package org.rookedsysc.membershipservice.application.service
+
+import org.rookedsysc.membershipservice.adapter.out.persistence.MembershipJpaEntity
+import org.rookedsysc.membershipservice.adapter.out.persistence.MembershipMapper
+import org.rookedsysc.membershipservice.application.port.`in`.dto.RegisterMembershipCommand
+import org.rookedsysc.membershipservice.application.port.`in`.usecase.RegisterMembershipUsecase
+import org.rookedsysc.membershipservice.application.port.out.RegisterMembershipPort
+import org.rookedsysc.membershipservice.domain.MemberShip
+import org.springframework.stereotype.Service
+
+@Service
+class RegisterMembershipService(
+    private val registerMembershipPort: RegisterMembershipPort,
+    private val membershipMapper: MembershipMapper
+) : RegisterMembershipUsecase {
+    override fun registerMembership(command: RegisterMembershipCommand): MemberShip {
+        var membershipJpaEntity: MembershipJpaEntity = membershipMapper.toJpaEntity(command)
+        membershipJpaEntity = registerMembershipPort.createMembership(membershipJpaEntity)
+
+        val membership: MemberShip = membershipMapper.toDomainEntity(membershipJpaEntity)
+        return membership
+    }
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/common/LogConfig.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/common/LogConfig.kt
@@ -1,0 +1,8 @@
+package org.rookedsysc.membershipservice.common
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+interface LogConfig {
+    val log: Logger get() = LoggerFactory.getLogger(this.javaClass)
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/common/constant/MembershipConstatns.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/common/constant/MembershipConstatns.kt
@@ -1,0 +1,7 @@
+package org.rookedsysc.membershipservice.common.constant
+
+class MembershipConstatns {
+    companion object {
+        const val MEMBERSHIP_REGISTER = "/membership"
+    }
+}

--- a/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/domain/MemberShip.kt
+++ b/membership-service/src/main/kotlin/org/rookedsysc/membershipservice/domain/MemberShip.kt
@@ -1,0 +1,10 @@
+package org.rookedsysc.membershipservice.domain
+
+class MemberShip(
+    val id: String,
+    val name: String,
+    val email: String,
+    val address: String,
+    val isValid: Boolean,
+    val isCorp: Boolean
+) {}

--- a/membership-service/src/main/resources/application.yaml
+++ b/membership-service/src/main/resources/application.yaml
@@ -1,0 +1,17 @@
+spring:
+  jpa:
+    properties:
+      dialect: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: validate
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+  datasource:
+    url: jdbc:mysql://192.168.1.24:3306/roky_pay?userSSL=false&useUnicode=true&allowPublicKeyRetrieval=true
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: df159357
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:db/migration

--- a/membership-service/src/main/resources/db/migration/V1__init.sql
+++ b/membership-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,8 @@
+CREATE TABLE membership (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    address VARCHAR(255) NOT NULL,
+    is_valid BOOLEAN NOT NULL,
+    is_corp BOOLEAN NOT NULL
+);

--- a/membership-service/src/test/kotlin/org/rookedsysc/membershipservice/application/port/in/dto/RegisterMembershipCommandTest.kt
+++ b/membership-service/src/test/kotlin/org/rookedsysc/membershipservice/application/port/in/dto/RegisterMembershipCommandTest.kt
@@ -1,0 +1,67 @@
+package org.rookedsysc.membershipservice.application.port.`in`.dto
+
+import jakarta.validation.ConstraintViolationException
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+import jakarta.validation.ValidatorFactory
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import kotlin.test.Test
+
+class RegisterMembershipCommandTest {
+
+    private lateinit var validator: Validator
+
+    @BeforeEach
+    fun setUp() {
+        val factory: ValidatorFactory = Validation.buildDefaultValidatorFactory()
+        validator = factory.validator
+    }
+
+    @Test
+    @DisplayName("유효한 RegisterMembershipCommand 테스트")
+    fun `test valid RegisterMembershipCommand`() {
+        // given
+        val command = RegisterMembershipCommand(
+            name = "John Doe",
+            email = "john.doe@example.com",
+            address = "123 Main St",
+            isValid = true,
+            isCorp = true
+        )
+
+        // when
+        val violations = validator.validate(command)
+
+        // then
+        assertEquals(0, violations.size)
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 RegisterMembershipCommand 생성 테스트")
+    fun testInvalidRegisterMembershipCommandCreation() {
+        // given // when // then
+        assertThrows(ConstraintViolationException::class.java) {
+            RegisterMembershipCommand(
+                name = "",
+                email = "invalid-email",
+                address = "",
+                isValid = false,
+                isCorp = true
+            )
+        }.also { exception ->
+            // violation 개수 검증
+            assertEquals(4, exception.constraintViolations.size)
+
+            // 각각의 위반 사항 검증
+            val violations = exception.constraintViolations.map { it.propertyPath.toString() }
+            assertAll(
+                { assertTrue(violations.contains("name")) },
+                { assertTrue(violations.contains("email")) },
+                { assertTrue(violations.contains("address")) },
+                { assertTrue(violations.contains("isValid")) }
+            )
+        }
+    }
+}


### PR DESCRIPTION
config: application.yaml flyway + db 연결 설정

feat: LogConfig 추가

feat: RegisterMembershipCommand 구현 및 Test 작성

feat: Membership Domain 구현

update: application.yaml ddl-auto validate로 변경

config: swagger dependency 추가

feat: db/migration membership schema 생성 쿼리 추가

feat: /membership/register API 구현

fix: MemberShip 객체 JSON 변환이 안되는 관계로 private 제거

feat: /membership/{membershipId} API 구현

docs: API 및 DTO Swagger 작성, Refactoring

## Related Issue

Related to : 해당 커밋에 관련된 이슈 번호

## Overview

- Feature 1 
- Feature 2 

## Result

Optional 




